### PR TITLE
[feat] 분산 추적(Tempo) 연동을 위한 OTel 의존성 및 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
+    implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,3 +16,8 @@ spring:
     properties:
       hibernate:
         format_sql: false # 운영 로그 깔끔하게
+
+management:
+  otlp:
+    tracing:
+      endpoint: http://tempo:4318/v1/traces

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,10 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, prometheus
+        include: health, info, prometheus, metrics
   metrics:
     tags:
       application: ${spring.application.name}
+  tracing:
+    sampling:
+      probability: 1.0


### PR DESCRIPTION
## 🔍 What
- 배포 환경(Infra)의 Grafana Tempo로 트레이싱 데이터를 전송하기 위해 Micrometer Tracing 및 OpenTelemetry 의존성을 추가했습니다.
- application.yml에 환경별(Dev/Prod) Tempo 엔드포인트 설정(http://tempo:4318)을 적용했습니다.
- common 모듈의 설정 파일이 서비스명을 덮어쓰는 문제를 해결하기 위해 불필요한 application.properties를 제거했습니다.

## 🧪 How to test
- 로컬에서 배포용 레포(Infra)의 docker-compose를 실행하여 Tempo 컨테이너를 띄웁니다.
- 이 PR 브랜치에서 애플리케이션(api)을 실행하고 API를 호출합니다. (예: GET /api/health 등)
- http://localhost:3000 (Grafana) → Explore → Data Source: Tempo 선택 → Search에서 **Service Name: api**가 보이는지 확인합니다.

## 🔗 Issue
- Closes: #7

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 분산 추적(Distributed Tracing) 기능 활성화로 요청 흐름을 더 정확히 추적 가능
  * 애플리케이션 메트릭 엔드포인트 확대로 모니터링 데이터 수집 개선
  * 프로덕션 환경에서 외부 추적 시스템과의 통합으로 운영 관찰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->