### PR TITLE
[refactor] Gateway 전역 CORS 설정 및 프론트엔드 환경 변수 연동

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,9 +20,7 @@ spring:
           uri: ${API_SERVER_URL:http://localhost:8081}
           predicates:
             - Path=/admin/**
-          filters:
-            - RewritePath=/api/(?<segment>.*), /$\{segment}
-
+            -
       default-filters:
         - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials, RETAIN_UNIQUE
 
@@ -31,10 +29,8 @@ spring:
         add-to-simple-url-handler-mapping: true
         cors-configurations:
           '[/**]':
-            allowedOriginPatterns:
-              - "http://localhost:3000"
-              - "http://localhost:3030"
-              - "${FRONTEND_URL:http://localhost:3030}"
+            # ⭐️ 쉼표로 구분된 문자열을 받아 여러 개의 패턴으로 인식하게 만듭니다
+            allowedOriginPatterns: "${FRONTEND_URL:http://localhost:3000,http://localhost:3030}"
 
             allowedMethods:
               - GET


### PR DESCRIPTION
## 🔍 What
- 마이크로서비스 간 중복 CORS 헤더로 인한 에러를 방지하기 위해 Gateway `application.yml`에 `RETAIN_UNIQUE` 옵션을 추가했습니다.
- 로컬 개발 환경과 배포 환경(OCI IP)을 유연하게 전환할 수 있도록 CORS `allowedOriginPatterns`를 환경 변수(`${FRONTEND_URL:http://localhost:3000}`)로 변경했습니다.
- 프론트엔드의 로컬/운영 모드에 맞춰 API 주소를 동적으로 주입받도록 `.env.development`와 `.env.production` 설정을 분리했습니다.

## 🧪 How to test
- **로컬 개발 테스트:**
  1. `gateway-repo` 애플리케이션을 별도의 환경변수 세팅 없이 그대로 실행합니다. (기본값인 `http://localhost:3000`이 맵핑됨)
  2. 로컬 프론트엔드(`npm run dev`)에서 Gateway 포트(`8080`)를 거쳐 API를 호출해 보고 CORS 에러가 발생하지 않는지 확인합니다.
- **운영 배포 시뮬레이션 (선택):**
  1. IntelliJ의 Run Configuration - Environment Variables 항목에 `FRONTEND_URL=http://146.56.104.192` 를 임의로 넣고 실행합니다.
  2. 로컬 프론트엔드(`localhost:3000`)에서 호출 시 의도적으로 CORS 차단 에러가 발생하는지 확인합니다. (배포 주소만 허용되었기 때문)

## 🔗 Issue
- Closes: #9

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **설정 변경**
  * 인증 및 관리자 엔드포인트 라우팅 경로 업데이트
  * CORS 매핑 활성화 및 허용 출처 설정을 환경변수 기반 단일 문자열로 전환
  * 지원되는 HTTP 메서드 확장: PUT, DELETE, OPTIONS 추가
  * 응답 헤더 중복 처리 방식을 덧붙임(기존 교체 방식 변경)
  * 모니터링/헬스 엔드포인트(health, info, metrics 등) 노출 유지 및 설정 주석 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->